### PR TITLE
Add zlib to fulfill nokogiri requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:sid
 
 RUN apt-get update -q
 RUN apt-get install -yq build-essential make
+RUN apt-get install -yq zlib1g-dev
 RUN apt-get install -yq ruby ruby-dev
 RUN apt-get install -yq python-pygments
 RUN apt-get install -yq nodejs


### PR DESCRIPTION
Nokogiri requires libxml2, that requires zlib.