### PR TITLE
Updated slide #7

### DIFF
--- a/assets/2015-07-01-deep-dive-into-docker-storage-drivers.html
+++ b/assets/2015-07-01-deep-dive-into-docker-storage-drivers.html
@@ -142,7 +142,7 @@ In [1]:
 
 # What happened here?
 
-- We created a *container* (~lightweight virtual machine),
+- We created a *container* (similar to a jailed process in BSD),
   <br/> with its own:
 
   - filesystem (based initially on a `python` image)


### PR DESCRIPTION
Removed virtual machine comparison and replaced it with BSD jail comparison; containers aren't similar to virtual machines as containers don't use [domains on hypervisors](https://libvirt.org/goals.html).

Personally, I see a lot of confusion for engineers in regards to comparing containers to virtual machines, so removing the reference and clarifying similarities will help promote understanding the difference of the two technologies.