### PR TITLE
Fix link to Natanel Copa talk

### DIFF
--- a/_posts/2020-03-01-quest-minimal-docker-images-part-2.markdown
+++ b/_posts/2020-03-01-quest-minimal-docker-images-part-2.markdown
@@ -170,7 +170,7 @@ very moment, 40% of electricity in Germany comes from coal-fired
 power plants](/assets/germany-datacenters-on-coal.png)
 
 If you want to know more about Alpine Linux internals, I recommend
-[this talk](https://dockercon.docker.com/watch/6nK1TVGjuTpFfnZNKEjCEr)
+[this talk](https://www.youtube.com/watch?v=sIG2P9k6EjA)
 by Natanel Copa.
 
 Alright, so Alpine is small. How can we use it for our own applications?


### PR DESCRIPTION
Hi, I am currently reading and really enjoying your series on minimising Docker image sizes.

I encountered a broken link in part 2 - I used the Wayback Machine to find the title of the talk, and then searched that title to find a mirror. Luckily it was uploaded on to the Docker YouTube channel: https://www.youtube.com/watch?v=sIG2P9k6EjA

I hope you don't mind me raising a PR to fix the link. Thanks for the blog posts!